### PR TITLE
code/dte: update reference to the XML schemas of "factura electrónica"

### DIFF
--- a/src/code/dte/README.md
+++ b/src/code/dte/README.md
@@ -4,7 +4,10 @@
 ## XML schemas
 
 - `DTE_v10.xsd`: "XSD principal y que incluye a los 3" otros XSD.
-  - Version 2011-05-30 (latest): [2011-05-30-schema_dte/schema_dte](2011-05-30-schema_dte/schema_dte)
+  - Version 2019-12-12 (latest): [2019-12-12-schema_cesion/schema_cesion](../rtc/2019-12-12-schema_cesion/schema_cesion)
+    - MD5: `ab4aae9dd23588f260d37a846e70439a`.
+    - SHA256: `1ba39d9bdaf96955cf6f3c36a7ce004cc6df18c4dd759705af44dc56f94b2d28`
+  - Version 2011-05-30: [2011-05-30-schema_dte/schema_dte](2011-05-30-schema_dte/schema_dte)
     - MD5: `e72ee34d798224f31a5127edda712bbf`.
     - SHA256: `5418f69b9ee64238b337e4d91fd255c567bc86353b15bb192812459b304067e8`
 
@@ -14,7 +17,10 @@
     - SHA256: `e86aae6ab21cbce8e93ddcf2df4f8b80cac42bab3c8da845d0756917e866aa2a`
 
 - `SiiTypes_v10.xsd`: "descripción de tipos de datos"
-  - Version 2011-05-30 (latest): [2011-05-30-schema_dte/schema_dte](2011-05-30-schema_dte/schema_dte)
+  - Version 2019-12-12 (latest): [2019-12-12-schema_cesion/schema_cesion](../rtc/2019-12-12-schema_cesion/schema_cesion)
+    - MD5: `5985df947f8b4d4c9daffcf50ca74b3a`.
+    - SHA256: `5002fef1cd9592de1191359f1995592d48d18f2274c5659bf2e47129807f434d`
+  - Version 2011-05-30: [2011-05-30-schema_dte/schema_dte](2011-05-30-schema_dte/schema_dte)
     - MD5: `b6a63aa427e3d528e46a7d94ccbdcb32`.
     - SHA256: `b6ba16b1698cae563b7aabde476f080b5f723769c6c2bb0c49b95e14da29b4dd`
 


### PR DESCRIPTION
Update the reference to the latest version of the XSD files `DTE_v10.xsd` and `SiiTypes_v10.xsd`.
Both files are part of the set of XML schemas for 'factura electrónica' and also for 'cesión (RTC)', there is a more recent version in the second set of 'cesión (RTC)', registered in this repository.

Ref: https://github.com/cl-sii-extraoficial/archivos-oficiales/pull/14